### PR TITLE
Extend index page with example and clear text reporter example output

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,37 +30,23 @@ Instead, Stryker empowers you to use what you like and focusses on being the bes
 </code></pre>
 <p>We call those modifications mutants. After the mutants have been found, they are applied one by one and your tests will be executed against them. If at least one of your tests fail, we say the mutant is <em>killed</em>. That's what we want! If no tests fail, it <em>survived</em>. The better your tests, the less mutants survive.</p>
 </div></div><div class="row"><div class="col-md-12 text-center"><h2>Output</h2>
-<p>Stryker will output the results in various different formats. One of the easiest output to read is via the clear text reporter:</p>
-<pre><code class="language-shell">[DEBUG] ClearTextReporter - Mutant killed!
-[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-[DEBUG] ClearTextReporter - Mutator: BinaryOperator
-[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
-[DEBUG] ClearTextReporter - +                 return user.age &gt; 18;
-[DEBUG] ClearTextReporter -
-[DEBUG] ClearTextReporter - Ran all tests for this mutant.
-[DEBUG] ClearTextReporter - Mutant killed!
-[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-[DEBUG] ClearTextReporter - Mutator: BinaryOperator
-[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
-[DEBUG] ClearTextReporter - +                 return user.age &lt; 18;
-[DEBUG] ClearTextReporter -
-[DEBUG] ClearTextReporter - Ran all tests for this mutant.
-[DEBUG] ClearTextReporter - Mutant killed!
-[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-[DEBUG] ClearTextReporter - Mutator: RemoveConditionals
-[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
-[DEBUG] ClearTextReporter - +                 return false;
-[DEBUG] ClearTextReporter -
-[DEBUG] ClearTextReporter - Ran all tests for this mutant.
-[DEBUG] ClearTextReporter - Mutant survived!
-[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-[DEBUG] ClearTextReporter - Mutator: RemoveConditionals
-[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
-[DEBUG] ClearTextReporter - +                 return true;
-[DEBUG] ClearTextReporter -
-[DEBUG] ClearTextReporter - Ran all tests for this mutant.
+<p>Stryker will output the results in various different formats. One of the easiest to read is the clear text reporter which output. You can activate it by adding <code>'clear-text'</code> to the <code>reporter</code> list in <code>stryker.conf.js</code>.</p>
+<pre><code class="language-shell">
+  Mutant killed!
+  /yourPath/yourFile.js: line 10:27
+  Mutator: BinaryOperator
+  -                 return user.age &gt;= 18;
+  +                 return user.age &gt; 18;
+
+  Mutant survived!
+  /yourPath/yourFile.js: line 10:27
+  Mutator: RemoveConditionals
+  -                 return user.age &gt;= 18;
+  +                 return true;
+
+
 </code></pre>
-<p>Here all the mutations from the paragraph are printed out by the clear text reporter. As we can see all of the mutants are catched by our tests except for the last one. This means there is probably a test missing that explicitly tests for an age lower than 18.</p>
+<p>The clear text reporter will output how exactly your code was modified and which mutator was used. It will then tell us if a mutant was killed, meaning that at least one test failed, or if it survived. The second mutation in this example is marked as a survivor. This means there is probably a test missing that explicitly tests for an age lower than 18.</p>
 </div></div><div class="row"><div class="col-md-12 text-center"><h2>Features</h2></div></div><div class="row"><div class="col-md-3 col-md-offset-1 col-sm-6"><div class="row"><div class="col-md-2 col-xs-2 icon-box text-center"><i class="fa fa-crosshairs"></i></div><div class="col-md-10 col-xs-10"><h4>Mutations</h4>
 <p>Control <a href="http://github.com/stryker-mutator/stryker#supported-mutators">more than 30 supported mutations</a>, or write your own.</p>
 </div></div></div><div class="col-md-3 col-sm-6"><div class="row"><div class="col-md-2 col-xs-2 icon-box text-center"><i class="fa fa-fast-forward"></i></div><div class="col-md-10 col-xs-10"><h4>Speed</h4>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,51 @@ It takes the best practices of existing mutation testing frameworks like <a href
 but with the open mentality of nodejs and the web. This is why Stryker is not a test runner or test framework.
 Indeed, why would it? There are already awesome test runners and test frameworks out there.
 Instead, Stryker empowers you to use what you like and focusses on being the best Mutation testing framework it can be.</p>
+</div></div><div class="row"><div class="col-md-12 text-center"><h2>An example</h2>
+<p>Say you're building an online casino, users can only enter the casino when they're over 18. So you write the following piece of code to check if someone is allowed to use the website:</p>
+<pre><code class="language-js">function isUserOldEnough(user) {
+  return user.age &gt;= 18;
+}
+</code></pre>
+<p>Stryker will find the return statement and decide to change it in a number of ways:</p>
+<pre><code class="language-js">/* 1 */ return user.age &gt; 18;
+/* 2 */ return user.age &lt; 18;
+/* 3 */ return false;
+/* 4 */ return true;
+</code></pre>
+<p>We call those modifications mutants. After the mutants have been found, they are applied one by one and your tests will be executed against them. If at least one of your tests fail, we say the mutant is <em>killed</em>. That's what we want! If no tests fail, it <em>survived</em>. The better your tests, the less mutants survive.</p>
+</div></div><div class="row"><div class="col-md-12 text-center"><h2>Output</h2>
+<p>Stryker will output the results in various different formats. One of the easiest output to read is via the clear text reporter:</p>
+<pre><code class="language-shell">[DEBUG] ClearTextReporter - Mutant killed!
+[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+[DEBUG] ClearTextReporter - Mutator: BinaryOperator
+[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
+[DEBUG] ClearTextReporter - +                 return user.age &gt; 18;
+[DEBUG] ClearTextReporter -
+[DEBUG] ClearTextReporter - Ran all tests for this mutant.
+[DEBUG] ClearTextReporter - Mutant killed!
+[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+[DEBUG] ClearTextReporter - Mutator: BinaryOperator
+[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
+[DEBUG] ClearTextReporter - +                 return user.age &lt; 18;
+[DEBUG] ClearTextReporter -
+[DEBUG] ClearTextReporter - Ran all tests for this mutant.
+[DEBUG] ClearTextReporter - Mutant killed!
+[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+[DEBUG] ClearTextReporter - Mutator: RemoveConditionals
+[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
+[DEBUG] ClearTextReporter - +                 return false;
+[DEBUG] ClearTextReporter -
+[DEBUG] ClearTextReporter - Ran all tests for this mutant.
+[DEBUG] ClearTextReporter - Mutant survived!
+[DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+[DEBUG] ClearTextReporter - Mutator: RemoveConditionals
+[DEBUG] ClearTextReporter - -                 return user.age &gt;= 18;
+[DEBUG] ClearTextReporter - +                 return true;
+[DEBUG] ClearTextReporter -
+[DEBUG] ClearTextReporter - Ran all tests for this mutant.
+</code></pre>
+<p>Here all the mutations from the paragraph are printed out by the clear text reporter. As we can see all of the mutants are catched by our tests except for the last one. This means there is probably a test missing that explicitly tests for an age lower than 18.</p>
 </div></div><div class="row"><div class="col-md-12 text-center"><h2>Features</h2></div></div><div class="row"><div class="col-md-3 col-md-offset-1 col-sm-6"><div class="row"><div class="col-md-2 col-xs-2 icon-box text-center"><i class="fa fa-crosshairs"></i></div><div class="col-md-10 col-xs-10"><h4>Mutations</h4>
 <p>Control <a href="http://github.com/stryker-mutator/stryker#supported-mutators">more than 30 supported mutations</a>, or write your own.</p>
 </div></div></div><div class="col-md-3 col-sm-6"><div class="row"><div class="col-md-2 col-xs-2 icon-box text-center"><i class="fa fa-fast-forward"></i></div><div class="col-md-10 col-xs-10"><h4>Speed</h4>

--- a/src/index.pug
+++ b/src/index.pug
@@ -71,39 +71,25 @@ block content
 
                 ## Output
 
-                Stryker will output the results in various different formats. One of the easiest output to read is via the clear text reporter:
+                Stryker will output the results in various different formats. One of the easiest to read is the clear text reporter which output. You can activate it by adding `'clear-text'` to the `reporter` list in `stryker.conf.js`.
                 ```shell
-                [DEBUG] ClearTextReporter - Mutant killed!
-                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-                [DEBUG] ClearTextReporter - Mutator: BinaryOperator
-                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
-                [DEBUG] ClearTextReporter - +                 return user.age > 18;
-                [DEBUG] ClearTextReporter -
-                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
-                [DEBUG] ClearTextReporter - Mutant killed!
-                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-                [DEBUG] ClearTextReporter - Mutator: BinaryOperator
-                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
-                [DEBUG] ClearTextReporter - +                 return user.age < 18;
-                [DEBUG] ClearTextReporter -
-                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
-                [DEBUG] ClearTextReporter - Mutant killed!
-                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-                [DEBUG] ClearTextReporter - Mutator: RemoveConditionals
-                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
-                [DEBUG] ClearTextReporter - +                 return false;
-                [DEBUG] ClearTextReporter -
-                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
-                [DEBUG] ClearTextReporter - Mutant survived!
-                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
-                [DEBUG] ClearTextReporter - Mutator: RemoveConditionals
-                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
-                [DEBUG] ClearTextReporter - +                 return true;
-                [DEBUG] ClearTextReporter -
-                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
+
+                  Mutant killed!
+                  /yourPath/yourFile.js: line 10:27
+                  Mutator: BinaryOperator
+                  -                 return user.age >= 18;
+                  +                 return user.age > 18;
+
+                  Mutant survived!
+                  /yourPath/yourFile.js: line 10:27
+                  Mutator: RemoveConditionals
+                  -                 return user.age >= 18;
+                  +                 return true;
+
+
                 ```
 
-                Here all the mutations from the paragraph are printed out by the clear text reporter. As we can see all of the mutants are catched by our tests except for the last one. This means there is probably a test missing that explicitly tests for an age lower than 18.
+                The clear text reporter will output how exactly your code was modified and which mutator was used. It will then tell us if a mutant was killed, meaning that at least one test failed, or if it survived. The second mutation in this example is marked as a survivor. This means there is probably a test missing that explicitly tests for an age lower than 18.
     .row
         .col-md-12.text-center
             h2 Features

--- a/src/index.pug
+++ b/src/index.pug
@@ -44,6 +44,68 @@ block content
                 Instead, Stryker empowers you to use what you like and focusses on being the best Mutation testing framework it can be.
     .row
         .col-md-12.text-center
+            :markdown-it
+
+                ## An example
+
+                Say you're building an online casino, users can only enter the casino when they're over 18. So you write the following piece of code to check if someone is allowed to use the website:
+
+                ```js
+                function isUserOldEnough(user) {
+                  return user.age >= 18;
+                }
+                ```
+
+                Stryker will find the return statement and decide to change it in a number of ways:
+                ```js
+                /* 1 */ return user.age > 18;
+                /* 2 */ return user.age < 18;
+                /* 3 */ return false;
+                /* 4 */ return true;
+                ```
+
+                We call those modifications mutants. After the mutants have been found, they are applied one by one and your tests will be executed against them. If at least one of your tests fail, we say the mutant is *killed*. That's what we want! If no tests fail, it *survived*. The better your tests, the less mutants survive.
+    .row
+        .col-md-12.text-center
+            :markdown-it
+
+                ## Output
+
+                Stryker will output the results in various different formats. One of the easiest output to read is via the clear text reporter:
+                ```shell
+                [DEBUG] ClearTextReporter - Mutant killed!
+                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+                [DEBUG] ClearTextReporter - Mutator: BinaryOperator
+                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
+                [DEBUG] ClearTextReporter - +                 return user.age > 18;
+                [DEBUG] ClearTextReporter -
+                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
+                [DEBUG] ClearTextReporter - Mutant killed!
+                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+                [DEBUG] ClearTextReporter - Mutator: BinaryOperator
+                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
+                [DEBUG] ClearTextReporter - +                 return user.age < 18;
+                [DEBUG] ClearTextReporter -
+                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
+                [DEBUG] ClearTextReporter - Mutant killed!
+                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+                [DEBUG] ClearTextReporter - Mutator: RemoveConditionals
+                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
+                [DEBUG] ClearTextReporter - +                 return false;
+                [DEBUG] ClearTextReporter -
+                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
+                [DEBUG] ClearTextReporter - Mutant survived!
+                [DEBUG] ClearTextReporter - /yourPath/yourFile.js: line 10:27
+                [DEBUG] ClearTextReporter - Mutator: RemoveConditionals
+                [DEBUG] ClearTextReporter - -                 return user.age >= 18;
+                [DEBUG] ClearTextReporter - +                 return true;
+                [DEBUG] ClearTextReporter -
+                [DEBUG] ClearTextReporter - Ran all tests for this mutant.
+                ```
+
+                Here all the mutations from the paragraph are printed out by the clear text reporter. As we can see all of the mutants are catched by our tests except for the last one. This means there is probably a test missing that explicitly tests for an age lower than 18.
+    .row
+        .col-md-12.text-center
             h2 Features
     .row
         .col-md-3.col-md-offset-1.col-sm-6

--- a/stylesheets/stryker.css
+++ b/stylesheets/stryker.css
@@ -43,4 +43,5 @@ h1, h2, h3 {
 }
 pre{
     padding: 0;
+    text-align: left;
 }

--- a/stylesheets/stryker.css
+++ b/stylesheets/stryker.css
@@ -14,12 +14,12 @@ body { padding-top: 50px; font-family: "Open Sans",Arial,sans-serif; }
 }
 .icon-box i{
     margin-top: 15px;
-} 
+}
 h1, h2, h3, .icon-box {
     color: #B74934;
 }
 h1, h2, h3 {
-    font-family: Carrois;   
+    font-family: Carrois;
 }
 .navbar-footer .navbar-text{
     font-size: 0.7em;


### PR DESCRIPTION
First draft of adding an example and output paragraph to the index.

Code examples need to be fixed.