### PR TITLE
Fix incorrect Stryker4s quickstart documentation

### DIFF
--- a/src/stryker4s/quickstart.pug
+++ b/src/stryker4s/quickstart.pug
@@ -20,6 +20,7 @@ block content
                 Also, make sure the `test-runner` is configured with the commands you need to run your unit tests.    
                 ```conf
                 stryker4s {
+                    log-level=INFO
                     mutate=[
                         "**/main/scala/**/*.scala"
                     ]

--- a/src/stryker4s/quickstart.pug
+++ b/src/stryker4s/quickstart.pug
@@ -15,23 +15,22 @@ block content
             h3 #[span.badge.badge-primary 3] Configure
             :markdown-it
                 After cloning the repository, create a `stryker4s.conf` file in the root of the Stryker4s repository. 
-                The configuration below contains a good starting point to run Stryker4s with the command test-runner. 
+                The configuration below shows all the default options Stryker4s uses. You can edit ones you want to change, or remove the ones that look good for your project. The default configuration will start a command test-runner for sbt. 
                 You will have to edit the `base-dir` to match the codebase you want to mutate. 
-                Also, make sure the `test-runner` is configured with the commands you need to run your unit tests.
-                
-                ```
+                Also, make sure the `test-runner` is configured with the commands you need to run your unit tests.    
+                ```conf
                 stryker4s {
-                  files: [
-                    "foo/bar/src/main/**/*.scala"
-                  ]
-                   base-dir: "/tmp/project"
-                   log-level: INFO
-                   test-runner: {
-                    type: commandrunner
-                    command: "sbt"
-                    args: "test"
-                  }
-                   reporters: ["console"]
+                    mutate=[
+                        "**/main/scala/**/*.scala"
+                    ]
+                    reporters=[
+                        console
+                    ]
+                    test-runner {
+                        args=test
+                        command=sbt
+                        type=commandrunner
+                    }
                 }
                 ```
     section.row


### PR DESCRIPTION
Some documentation in the Stryker4s quickstart was a bit outdated. This fixes that.

Also, it's a bit annoying having to update the handbook in two places 😁