### PR TITLE
Add link to roadmap for Stryker4s

### DIFF
--- a/src/stryker4s/index.pug
+++ b/src/stryker4s/index.pug
@@ -10,7 +10,9 @@ block content
         Currently Stryker4s is still in early development, which means it's propably not ready for large projects just yet.
 
         However, this shouldn't hold you back to give Stryker4s a try. 
-        An easy way to get started is to use the quickstart.
+        An easy way to get started is to use the quickstart. Or interested in the future of Stryker4s?
     
-    a.btn.btn-primary.btn-lg(href="/stryker4s/quickstart") To quickstart
+    a.btn.btn-primary.btn-lg(href="/stryker4s/quickstart") To quickstart 
+    |  
+    a.btn.btn-primary.btn-lg(href="https://github.com/stryker-mutator/stryker4s/blob/master/docs/ROADMAP.md") To roadmap  
     p


### PR DESCRIPTION
A small button to link to the roadmap.
This is a fast version which i my opinion might be replaced by #107 if we wanted that.