### PR TITLE
Import only used bootstrap dependencies

### DIFF
--- a/src/scss/all.scss
+++ b/src/scss/all.scss
@@ -3,8 +3,8 @@ $secondary: #b74934;
 $accent: #F1C40F;
 $code-color: $secondary;
 
-@import "../../node_modules/bootstrap/scss/bootstrap";
 @import "../../node_modules/highlight.js/styles/github";
+@import "./bootstrap";
 @import "./stryker/container-fix";
 @import "./stryker/fork-me-banner";
 @import "./stryker/preview-ribbon";

--- a/src/scss/bootstrap.scss
+++ b/src/scss/bootstrap.scss
@@ -1,0 +1,19 @@
+// Required
+@import "../../node_modules/bootstrap/scss/functions";
+@import "../../node_modules/bootstrap/scss/variables";
+@import "../../node_modules/bootstrap/scss/mixins";
+
+// Optional
+@import "../../node_modules/bootstrap/scss/button-group";
+@import "../../node_modules/bootstrap/scss/buttons";
+@import "../../node_modules/bootstrap/scss/card";
+@import "../../node_modules/bootstrap/scss/code";
+@import "../../node_modules/bootstrap/scss/grid";
+@import "../../node_modules/bootstrap/scss/list-group";
+@import "../../node_modules/bootstrap/scss/images";
+@import "../../node_modules/bootstrap/scss/jumbotron";
+@import "../../node_modules/bootstrap/scss/nav";
+@import "../../node_modules/bootstrap/scss/navbar";
+@import "../../node_modules/bootstrap/scss/reboot";
+@import "../../node_modules/bootstrap/scss/type";
+@import "../../node_modules/bootstrap/scss/utilities";


### PR DESCRIPTION
I've changed the SASS bootstrap imports to only use what's needed, instead of everything from bootstrap. This changes the created CSS size from 126KB to 79KB, meaning visitors can start killing mutants even faster!