### PR TITLE
Fix Features responsiveness

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -134,7 +134,6 @@ block content
                         ### Test runner agnostic
 
                         Run tests with your favorite test runner.
-    .row
         .col-md-4.col-sm-6
             .row
                 .col-md-2.col-2.icon-box


### PR DESCRIPTION
On the main page, at the Features bit, I noticed there's a small error on certain device sizes. This fixes that by having all 'Features' in 1 row and just letting Bootstrap and flex-box handle the sizing.

Before:
![screen shot 2018-11-30 at 11 19 31](https://user-images.githubusercontent.com/10114577/49283400-ec7f4880-f491-11e8-99a4-2a835214c5e5.png)

After:
![screen shot 2018-11-30 at 11 20 45](https://user-images.githubusercontent.com/10114577/49283437-03259f80-f492-11e8-8d3a-b1974ef2b07f.png)
