### PR TITLE
feat: add permalinks to section headings

### DIFF
--- a/src/blog.pug
+++ b/src/blog.pug
@@ -3,8 +3,8 @@ extends ./layout/layout.pug
 block content
     .row
         .col-md-12
+            h1 Blog
             :markdown-it
-                # Blog
                 Welcome to the blog of Stryker. Expect an article every 2 weeks to inform developers about the usage of Stryker and the new possibities it brings.
 
             each blog in blogs

--- a/src/example.pug
+++ b/src/example.pug
@@ -1,9 +1,8 @@
 extends ./layout/layout.pug
 
 block content
+    h1 Welcome to the RoboBar
     :markdown-it
-        # Welcome to the RoboBar
-
         > An introduction to mutation testing
 
         _How code coverage of 100% could mean only 60% is tested._

--- a/src/index.pug
+++ b/src/index.pug
@@ -16,7 +16,8 @@ block docs-header
 block content
     .row
         .col-md-12.text-center
-            h2 Getting started with Stryker
+            :markdown-it
+                ## Getting started with Stryker
             .row
                 a.col-md-4(title="Stryker for JavaScript and friends", href="/stryker/")
                     figure
@@ -105,43 +106,40 @@ block content
                 The clear text reporter will output how exactly your code was modified and which mutator was used. It will then tell us if a mutant was killed, meaning that at least one test failed, or if it survived. The second mutation in this example is marked as a survivor. This means there is probably a test missing that explicitly tests for age lower than 18.
     .row
         .col-md-12
-            h2 Features
+            :markdown-it
+                ## Features
     .row.mt-3
         .col-md-4.col-sm-6
             .row
                 .col-md-2.col-2.icon-box
                     i.fa.fa-crosshairs
                 .col-md-10.col-10.mt-2
+                    h3 Mutations
                     :markdown-it
-                        ### Mutations
-
                         Control [more than 30 supported mutations](/mutators.html), or write your own.
         .col-md-4.col-sm-6
             .row
                 .col-md-2.col-2.icon-box
                     i.fa.fa-shipping-fast
                 .col-md-10.col-10.mt-2
+                    h3 Speed
                     :markdown-it
-                        ### Speed
-
                         Use code analysis and parallel test runner processes to speed things up.
         .col-md-4.col-sm-6
             .row
                 .col-md-2.col-2.icon-box
                     i.fa.fa-globe-americas
                 .col-md-10.col-10.mt-2
+                    h3 Test runner agnostic
                     :markdown-it
-                        ### Test runner agnostic
-
                         Run tests with your favorite test runner.
         .col-md-4.col-sm-6
             .row
                 .col-md-2.col-2.icon-box
                     i.fa.fa-users
                 .col-md-10.col-10.mt-2
+                    h3 Open source
                     :markdown-it
-                        ### Open source
-
                         Free as in Speech. Maintained by the open source community at
                         [GitHub](http://github.com/stryker-mutator/stryker).
         .col-md-4.col-sm-6
@@ -149,25 +147,24 @@ block content
                 .col-md-2.col-2.icon-box
                     i.fa.fa-cogs
                 .col-md-10.col-10.mt-2
+                    h3 Multilingual
                     :markdown-it
-                        ### Multilingual
-
                         Stryker has support for [JavaScript & TypeScript](/stryker/), [C#](/stryker-net/) and [Scala](/stryker4s/)
         .col-md-4.col-sm-6
             .row
                 .col-md-2.col-2.icon-box
                     i.fa.fa-chart-bar
                 .col-md-10.col-10.mt-2
+                    h3 Clever reports
                     :markdown-it
-                        ### Clever reports
-
                         Use [clever reports](https://github.com/stryker-mutator/stryker/tree/master/packages/html-reporter#readme)
                         to sniff out surviving mutants and improve test effectiveness.
     
     .row
         .col-md-12.mt-3
-            h2 Info Support
             :markdown-it
+                ## Info Support
+
                 Stryker is sponsored by [Info Support](https://www.infosupport.com/). They provide our awesome swag, host Stryker hackathons and provide time for their developers to work on Stryker and other open source projects. Check them out at [opensource.infosupport.com](https://opensource.infosupport.com/).
 
     .row

--- a/src/layout/section-layout.pug
+++ b/src/layout/section-layout.pug
@@ -1,6 +1,7 @@
 extends ./layout.pug
 
 block prepend content
+    :markdown-it
     .row
         .col-md-3
             .card.sticky-top-70.mb-3

--- a/src/scss/stryker/links.scss
+++ b/src/scss/stryker/links.scss
@@ -7,21 +7,19 @@ a[target="_blank"]:after {
 }
 
 .stryker-permalink {
-    width: 25px;
-    height: 25px;
-    font-size: 15px;
-    float: left;
-    margin-left: -25px;
-    vertical-align: center;
-    display: flex;
-    align-items: center;
     &::before {
-        content: ""
+        content: "🔗";
+        text-decoration: none;
+        visibility: hidden;
+        font-size: 15px;
+        float: left;
+        margin-left: -20px;
+        padding-right: 4px;
     }
     &:hover {
         text-decoration: none;
         &::before {
-            content: "🔗"
+            visibility: visible;
         }
     }
 }
@@ -34,7 +32,7 @@ h1, h2, h3 {
     &:hover {
         .stryker-permalink {
             &::before {
-                content: "🔗"
+                visibility: visible;
             }
         }
     }

--- a/src/scss/stryker/links.scss
+++ b/src/scss/stryker/links.scss
@@ -8,11 +8,13 @@ a[target="_blank"]:after {
 
 .stryker-permalink {
     width: 25px;
-    height: 15px;
-    font-size: 16px;
+    height: 25px;
+    font-size: 15px;
     float: left;
-    line-height: 1;
     margin-left: -25px;
+    vertical-align: center;
+    display: flex;
+    align-items: center;
     &::before {
         content: ""
     }
@@ -24,14 +26,23 @@ a[target="_blank"]:after {
     }
 }
 
-h2 {
+h1, h2, h3 {
     display: flex;
     align-items: center;
+    padding-top: 70px;
+    margin-top: -70px;
     &:hover {
         .stryker-permalink {
             &::before {
                 content: "🔗"
             }
         }
+    }
+    &::before {
+        display: block; 
+        content: " "; 
+        margin-top: -75px; 
+        height: 75px; 
+        visibility: hidden; 
     }
 }

--- a/src/scss/stryker/links.scss
+++ b/src/scss/stryker/links.scss
@@ -19,7 +19,7 @@ a[target="_blank"]:after {
 h1, h2, h3 {
     display: flex;
     align-items: center;
-    scroll-margin-block: 70px;
+    scroll-margin: 70px;
     &:hover {
         .stryker-permalink {
             visibility: visible;

--- a/src/scss/stryker/links.scss
+++ b/src/scss/stryker/links.scss
@@ -5,3 +5,33 @@ a[target="_blank"]:after {
 .navbar-nav a:after { 
     content: '';
 }
+
+.stryker-permalink {
+    width: 25px;
+    height: 15px;
+    font-size: 16px;
+    float: left;
+    line-height: 1;
+    margin-left: -25px;
+    &::before {
+        content: ""
+    }
+    &:hover {
+        text-decoration: none;
+        &::before {
+            content: "🔗"
+        }
+    }
+}
+
+h2 {
+    display: flex;
+    align-items: center;
+    &:hover {
+        .stryker-permalink {
+            &::before {
+                content: "🔗"
+            }
+        }
+    }
+}

--- a/src/scss/stryker/links.scss
+++ b/src/scss/stryker/links.scss
@@ -7,40 +7,25 @@ a[target="_blank"]:after {
 }
 
 .stryker-permalink {
-    &::before {
-        content: "🔗";
-        text-decoration: none;
-        visibility: hidden;
-        font-size: 15px;
-        float: left;
-        margin-left: -20px;
-        padding-right: 4px;
-    }
+    visibility: hidden;
+    font-size: 15px;
+    float: left;
+    margin-left: -20px;
     &:hover {
         text-decoration: none;
-        &::before {
-            visibility: visible;
-        }
     }
 }
 
 h1, h2, h3 {
     display: flex;
     align-items: center;
-    padding-top: 70px;
-    margin-top: -70px;
+    scroll-margin-block: 70px;
     &:hover {
         .stryker-permalink {
-            &::before {
-                visibility: visible;
-            }
+            visibility: visible;
         }
     }
-    &::before {
-        display: block; 
-        content: " "; 
-        margin-top: -75px; 
-        height: 75px; 
-        visibility: hidden; 
+    .text-center & {
+        justify-content: center;
     }
 }

--- a/src/stryker-net/quickstart.pug
+++ b/src/stryker-net/quickstart.pug
@@ -7,8 +7,9 @@ block content
                 Install Stryker using [NuGet](https://www.nuget.org/).
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 1] Install
             :markdown-it
+                ## 1 Install
+                
                 To install Stryker.NET on your test project add the following lines to the root of your .csproj file. on your test project.
 
                 ```
@@ -25,16 +26,20 @@ block content
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 2] Let's kill some mutants
-            p Run Stryker.NET to mutation test your project
-            pre.stryker-install
-                code 
-                    | dotnet stryker
+            :markdown-it
+                ## 2 Let's kill some mutants
+
+                Stryker.NET to mutation test your project
+
+                ```
+                dotnet stryker
+                ```
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 3] Configure
             :markdown-it
+                ## 3 Configure
+
                 Stryker will always look for a `stryker-config.json` file in the root of the test project. When found it will use the parameters in the file.
 
                 ```js

--- a/src/stryker/quickstart.pug
+++ b/src/stryker/quickstart.pug
@@ -10,8 +10,9 @@ block content
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 1] Prepare
             :markdown-it
+                ## 1 Prepare
+            
                 Make sure you have npm and nodejs installed. Open a terminal / command prompt and cd to the root of your project you want to mutation test.
             
                 ```shell
@@ -20,8 +21,9 @@ block content
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 2] Install
             :markdown-it
+                ## 2 Install
+
                 The easiest way to get started with Stryker is by installing the stryker-cli globally. 
                 It is a small package which forwards commands to your local stryker instance. 
                             
@@ -39,9 +41,9 @@ block content
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 3] Configure
-
             :markdown-it
+                ## 3 Configure
+
                 Run this command the configure stryker.
                 
                 ```shell
@@ -58,9 +60,9 @@ block content
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 4] Let's kill some mutants
-
             :markdown-it
+                ## 4 Let's kill some mutants
+
                 Run stryker to mutation test your project
                 
                 ```shell
@@ -69,8 +71,9 @@ block content
             hr/
     section.row
         .col-md-12
-            h3 #[span.badge.badge-primary 5] What's next?
             :markdown-it
+                ## 5 What's next?
+
                 Having troubles? Try enabling debug logging by adding `logLevel: 'debug'` to your stryker.conf.js. 
                 To also see output of your test runner, use `logLevel: 'trace'`. 
                 You can also have a look at the [readme file of stryker](https://github.com/stryker-mutator/stryker/tree/master/packages/core#readme) for more information about the configuration.

--- a/tasks/markdown-it.js
+++ b/tasks/markdown-it.js
@@ -24,9 +24,40 @@ function link_open(tokens, idx, options, _ /*env*/ , self) {
   return self.renderToken(tokens, idx, options);
 };
 
+// Source - https://github.com/nodejs/nodejs.dev/blob/master/src/util/createSlug.js
+function slugify(title) {
+  let slug = title.toLowerCase().trim();
+
+  const sets = [
+    {to: '-and-', from: /&/ }, // Replace &
+    {to: '-', from: /(\/|_|,|:|;|\\|\ |\.|\?)/g } // Replace /_,:;\.? and whitespace
+  ];
+  
+  sets.forEach(set => {
+    slug = slug.replace(set.from, set.to);
+  });
+
+  return slug
+    .replace(/[^\w\-]+/g, '') // Remove any non word characters
+    .replace(/\-\-+/g, '-')   // Replace multiple hyphens with single
+    .replace(/^-/, '')        // Remove any leading hyphen
+    .replace(/-$/, '');       // Remove any trailing hyphen
+}
+
 module.exports = function markdownIt(text) {
   return md.render(text, {
-    plugins: ['markdown-it-anchor'], // Make sure headers have id's so they can be anchored
+    plugins: [
+      [
+        'markdown-it-anchor', // Make sure headers have id's so they can be anchored
+        {
+          permalink: true,
+          permalinkBefore: true,
+          permalinkSymbol: '',
+          permalinkClass: 'stryker-permalink',
+          slugify
+        }
+      ]
+    ],
     html: true,
     renderRules: {
       link_open

--- a/tasks/markdown-it.js
+++ b/tasks/markdown-it.js
@@ -52,7 +52,7 @@ module.exports = function markdownIt(text) {
         {
           permalink: true,
           permalinkBefore: true,
-          permalinkSymbol: '',
+          permalinkSymbol: '🔗',
           permalinkClass: 'stryker-permalink',
           slugify
         }


### PR DESCRIPTION
As proposed in #123. Adds a small clickable icon when hovering a heading. Clicking that icon updates the URL to point to that section. It looks like this:

<img width="363" alt="skarmavbild 2019-02-27 kl 15 39 20" src="https://user-images.githubusercontent.com/16004130/53505907-2540b500-3ab5-11e9-9bd6-cf7189a0cce3.png">

This also adds a custom function to generate pretty slugs. Instead of `#but-wait%2C-what-about-code-coverage%3F` we now get `#but-wait-what-about-code-coverage` 🙂 