### PR TITLE
Update quick-start on how to configure log levels

### DIFF
--- a/src/stryker4s/quickstart.pug
+++ b/src/stryker4s/quickstart.pug
@@ -31,5 +31,5 @@ block content
  
                 ### 4 Having trouble? 
 
-                Having troubles? Try enabling debug logging by adding `log-level: debug` to your `stryker4s.conf`.
+                Having troubles? Try enabling debug logging, for more information on how to enable debug logging visit our [configuration page](https://github.com/stryker-mutator/stryker4s/blob/master/docs/CONFIGURATION.md#log-level).
                 If you are having issues please let us know by [reporting an issue](https://github.com/stryker-mutator/stryker4s/issues/new) or talk to us on [Gitter](https://gitter.im/stryker-mutator/stryker4s).


### PR DESCRIPTION
Change some text to no longer indicate on how you can configure log levels in de config (since that's removed). Instead, I refer to our up to date configuration page.