### PR TITLE
Fix "View me on GitHub" icon margin

### DIFF
--- a/src/scss/stryker/fork-me-banner.scss
+++ b/src/scss/stryker/fork-me-banner.scss
@@ -15,7 +15,7 @@
 
 #forkme_banner i {
     font-size: 25px;
-    margin: 0px 5px;
+    margin-left: 7px;
 }
 
 #forkme_banner:hover {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10114577/56424772-ef000480-62b1-11e9-9e19-11da2840c149.png)
After:

![image](https://user-images.githubusercontent.com/10114577/56424996-c9bfc600-62b2-11e9-89ab-12175b438211.png)

Spacing is now the same on both sides. It annoyed me
