### PR TITLE
Support manually releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches: ['develop']
 


### PR DESCRIPTION
In preparation for the new site, we should be able to release manually to make it easy to revert the test release(s)