### PR TITLE
feat(sidebar): allow for a custom sidebar per repo

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,17 +1,19 @@
 // @ts-check
 module.exports = {
-  General: [
-    'General/introduction',
-    'General/example',
-    'General/dashboard',
-    'General/faq',
-  ],
-  // @ts-expect-error
-  'Mutation Testing': require('./docs/mutation-testing-elements/sidebar'),
-  // @ts-expect-error
-  'Stryker': require('./docs/stryker/sidebar'),
-  // @ts-expect-error
-  'Stryker.NET': require('./docs/stryker-net/sidebar'),
-  // @ts-expect-error
-  'Stryker4s': require('./docs/stryker4s/sidebar'),
+  docs: {
+    General: [
+      'General/introduction',
+      'General/example',
+      'General/dashboard',
+      'General/faq',
+    ],
+    // @ts-expect-error
+    'Mutation Testing': require('./docs/mutation-testing-elements/sidebar'),
+    // @ts-expect-error
+    'Stryker': require('./docs/stryker/sidebar'),
+    // @ts-expect-error
+    'Stryker.NET': require('./docs/stryker-net/sidebar'),
+    // @ts-expect-error
+    'Stryker4s': require('./docs/stryker4s/sidebar'),
+  }
 }

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,19 +1,14 @@
 // @ts-check
 module.exports = {
   docs: {
-    General: [
-      'General/introduction',
-      'General/example',
-      'General/dashboard',
-      'General/faq',
-    ],
+    General: ['General/introduction', 'General/example', 'General/dashboard', 'General/faq'],
     // @ts-expect-error
     'Mutation Testing': require('./docs/mutation-testing-elements/sidebar'),
     // @ts-expect-error
-    'Stryker': require('./docs/stryker/sidebar'),
+    Stryker: require('./docs/stryker/sidebar'),
     // @ts-expect-error
     'Stryker.NET': require('./docs/stryker-net/sidebar'),
     // @ts-expect-error
-    'Stryker4s': require('./docs/stryker4s/sidebar'),
-  }
-}
+    Stryker4s: require('./docs/stryker4s/sidebar'),
+  },
+};

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,73 +1,17 @@
 // @ts-check
-const path = require('path');
-const fs = require('fs');
-
-/**
- * @param {string} base
- * @param {string} rest
- * @returns {string}
- */
-function toRelativePath(base, rest) {
-  if (base === 'docs' || base.length === 0) return rest;
-  else return `${base}/${rest}`;
+module.exports = {
+  General: [
+    'General/introduction',
+    'General/example',
+    'General/dashboard',
+    'General/faq',
+  ],
+  // @ts-expect-error
+  'Mutation Testing': require('./docs/mutation-testing-elements/sidebar'),
+  // @ts-expect-error
+  'Stryker': require('./docs/stryker/sidebar'),
+  // @ts-expect-error
+  'Stryker.NET': require('./docs/stryker-net/sidebar'),
+  // @ts-expect-error
+  'Stryker4s': require('./docs/stryker4s/sidebar'),
 }
-
-/**
- * @param {string} dir
- */
-function directoryNameMapping(dir) {
-  switch (dir) {
-    case 'stryker4s':
-      return 'Stryker4s';
-    case 'stryker-net':
-    case 'stryker.net':
-      return 'Stryker.NET';
-    case 'stryker':
-      return 'Stryker';
-    case 'mutation-testing-elements':
-      return 'Mutation Testing';
-    default:
-      return dir;
-  }
-}
-
-/**
- * @param {string} dir directory we're working on
- * @param {string} acc full filepath
- * @param {string} relativePath Path relative to docs directory
- * @typedef {{[location: string]: (string | Sidebar)[]}} Sidebar
- * @returns {Sidebar}
- */
-function filesInDir(dir, acc, relativePath) {
-  const fullDir = path.resolve(acc, dir);
-
-  const inDirectory = fs.readdirSync(fullDir);
-  /**
-   * @type {string[]} files
-   */
-  const files = [];
-  /**
-   * @type {string[]} directories
-   */
-  const directories = [];
-  inDirectory
-    .filter((_) => !_.startsWith('.'))
-    .forEach((f) => {
-      const fullPath = `${fullDir}/${f}`;
-      if (fs.lstatSync(fullPath).isDirectory()) {
-        directories.push(f);
-      } else if (f.endsWith('.md') || f.endsWith('.mdx')) {
-        const withoutMd = f.split('.md')[0];
-        files.push(`${relativePath}/${withoutMd}`);
-      }
-    });
-
-  let dirname = directoryNameMapping(dir);
-
-  return {
-    [dirname]: [...files, ...directories.map((d) => filesInDir(d, fullDir, toRelativePath(relativePath, d)))],
-  };
-}
-const docs = filesInDir('docs', path.resolve('.'), '');
-
-module.exports = docs;


### PR DESCRIPTION
Allow for a custom sidebar to be defined per repository.

The `sidebar.json` (or `sidebar.js` if you prefer a node module) should contain a valid [sidebar object](https://v2.docusaurus.io/docs/docs-introduction#sidebar-object). The document root is part of the URL, so [document ids](https://v2.docusaurus.io/docs/docs-introduction#document-id) should be prefixed with the repository name.
