### PR TITLE
feat: add docsearch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,6 +113,10 @@ module.exports = {
       // Optional fields.
       anonymizeIP: true, // Should IPs be anonymized?
     },
+    algolia: {
+      apiKey: '5cbcde3fafdb1be491bb20c96a86a211',
+      indexName: 'stryker-mutator',
+    },
   },
   presets: [
     [


### PR DESCRIPTION
[Docusaurus supports something](https://v2.docusaurus.io/docs/search/) called [DocSearch](https://docsearch.algolia.com/) which is a service that indexes a documentation website every 24 hours and creates a search bar to put on the website. I've requested this for the stryker-mutator.io website (under the strykermutator.npa@gmail.com email). It supports search of both headers and deep text and it looks a little something like this:

![image](https://user-images.githubusercontent.com/10114577/99946655-00a36b00-2d77-11eb-8ac3-dcfbe58bbb8e.png)

I've created a little demo video here: https://imgur.com/a/ctLok7U

It also supports a dedicated search page for more results:

![image](https://user-images.githubusercontent.com/10114577/99946162-309e3e80-2d76-11eb-931a-9b4a33081cf0.png)

The API key should be public as it is should be included in a script in the website.
