### PR TITLE
Temporarily disable Google Analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,11 +139,12 @@ module.exports = {
       theme: require('prism-react-renderer/themes/github'),
       darkTheme: require('prism-react-renderer/themes/dracula'),
     },
-    googleAnalytics: {
-      trackingID: 'UA-104444094-1',
-      // Optional fields.
-      anonymizeIP: true, // Should IPs be anonymized?
-    },
+    // Disabled until we add a cookie banner
+    // googleAnalytics: {
+    //   trackingID: 'UA-104444094-1',
+    //   // Optional fields.
+    //   anonymizeIP: true, // Should IPs be anonymized?
+    // },
     algolia: {
       apiKey: '5cbcde3fafdb1be491bb20c96a86a211',
       indexName: 'stryker-mutator',


### PR DESCRIPTION
Using Google Analytics without a consent banner like we do now is not GDPR-compliant. Unfortunately, there's no built-in way to show a cookie banner in Docusaurus. See also this [open issue](https://docusaurus-2.netlify.app/feedback/p/cookie-consent-component).

This might be a small site, but I still think we should be careful in GDPR compliance and respect users' privacy. So with this PR, I've disabled Google Analytics until either Docusaurus adds a cookie banner or we add one ourselves.