### PR TITLE
Fix grammar

### DIFF
--- a/blog/2018-10-06-mutation-switching.md
+++ b/blog/2018-10-06-mutation-switching.md
@@ -117,7 +117,7 @@ def filterOddAnd(specialNumber: Int): List[Int] = {
 }
 ```
 
-With this code base `filter` and `filterNot` could be mutated to there counterparts.
+With this code base `filter` and `filterNot` could be mutated to their counterparts.
 This would give us the following code base if we implement the pattern match at the direct position.
 
 ```scala


### PR DESCRIPTION
Fixes a small mistake on the [Mutation switching in Stryker4s](https://stryker-mutator.io/blog/mutation-switching/#:~:text=be%20mutated%20to-,there,-counterparts.%20This%20would) blog.