### PR TITLE
fix(docs): update example mutation testing command

### DIFF
--- a/docs/General/example.mdx
+++ b/docs/General/example.mdx
@@ -49,7 +49,7 @@ Why don't you give it a try? 😁
 1. Review the 100% code coverage score. Open up the code coverage report located in the `reports/coverage` directory.
 1. Run mutation testing with [Stryker](https://stryker-mutator.io)
    ```bash
-   npm run stryker
+   npm run test:mutation
    ```
 1. Review the 50% mutation score. Open up the mutation report located in the `reports/mutation` directory.
 1. Run the website with `npm start`. Can you find the bug?


### PR DESCRIPTION
The __step 7__ in [the example](https://stryker-mutator.io/docs/General/example/) to run mutations testing with Stryker suggests to run `npm run stryker`. Altho, the `stryker` script has been renamed to `test:mutation` in [this commit](https://github.com/stryker-mutator/robobar-example/commit/9699ff5d39e9fe8559cbda2b546872dca1b94fa3#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R18) leading to the following error when blindly following the steps:

```shell
npm ERR! Missing script: "stryker"
npm ERR!
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
```

This pull request updates the example to use `npm run test:mutation` instead.