### PR TITLE
Minor improvements in example doc

### DIFF
--- a/docs/General/example.mdx
+++ b/docs/General/example.mdx
@@ -59,6 +59,7 @@ Why don't you give it a try? 😁
 If you want to install stryker yourself, step back in history using git:
 
 ```bash
+git reset --hard
 git checkout e92b8d4
 npm install
 ```

--- a/docs/General/example.mdx
+++ b/docs/General/example.mdx
@@ -46,7 +46,7 @@ Why don't you give it a try? 😁
    ```bash
    npm test
    ```
-1. Review the 100% code coverage score. Open up the code coverage report located in the `reports/coverage` directory.
+1. Review the 100% code coverage score. Open up the code coverage report located in the `reports/coverage/lcov-report/index.html` file.
 1. Run mutation testing with [Stryker](https://stryker-mutator.io)
    ```bash
    npm run test:mutation


### PR DESCRIPTION
Hello guys! I found this project during the current hacktoberfest and decided to give it a shot and try contributing to it.

So, this is a simple PR with 2 minor improvements in the example doc:

1. I made the location of the test coverage file more specific in step 6 of the "Try it yourself" section. I make this change because when I was reading this part, I had some confusion to find which was the correct test coverage file that was being referred to by the documentation.
2. I added the command `git reset --hard` at the beginning of the commands section "Try to install stryker yourself". That's because the website commands are intended to be direct and not leave anyone lost, however, `git checkout` does not work directly for those who came to this command reading and doing the tutorial. That's why I put a command before the checkout so that everything works and the reader doesn't have his flow broken.

I hope to hear from you guys what you think about my suggestions, thanks!