### PR TITLE
build: use swc-loader to speed up build

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,6 +2,23 @@
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
+  webpack: {
+    jsLoader: (isServer) => ({
+      loader: require.resolve('swc-loader'),
+      options: {
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            tsx: true,
+          },
+          target: 'es2020',
+        },
+        module: {
+          type: isServer ? 'commonjs' : 'es6',
+        },
+      },
+    }),
+  },
   title: 'Stryker Mutator',
   tagline: 'Test your tests with mutation testing.',
   url: 'https://stryker-mutator.io',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,10 +21,12 @@
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "2.1.0",
+        "@swc/core": "1.3.8",
         "@tsconfig/docusaurus": "1.0.6",
         "@types/mermaid": "9.1.0",
         "prettier": "2.7.1",
         "rimraf": "3.0.2",
+        "swc-loader": "0.2.3",
         "typescript": "4.8.4"
       }
     },
@@ -3106,6 +3108,306 @@
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
       }
+    },
+    "node_modules/@swc/core": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.8.tgz",
+      "integrity": "sha512-EEinXtV7MvzWt1dgqnkfUaxCwPnSo3ZeWQzTpppCZFkM9hn+kfViTig2aS1aoXvwi/SsDZ51DDs4st8xr4yqhQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "swcx": "run_swcx.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-android-arm-eabi": "1.3.8",
+        "@swc/core-android-arm64": "1.3.8",
+        "@swc/core-darwin-arm64": "1.3.8",
+        "@swc/core-darwin-x64": "1.3.8",
+        "@swc/core-freebsd-x64": "1.3.8",
+        "@swc/core-linux-arm-gnueabihf": "1.3.8",
+        "@swc/core-linux-arm64-gnu": "1.3.8",
+        "@swc/core-linux-arm64-musl": "1.3.8",
+        "@swc/core-linux-x64-gnu": "1.3.8",
+        "@swc/core-linux-x64-musl": "1.3.8",
+        "@swc/core-win32-arm64-msvc": "1.3.8",
+        "@swc/core-win32-ia32-msvc": "1.3.8",
+        "@swc/core-win32-x64-msvc": "1.3.8"
+      }
+    },
+    "node_modules/@swc/core-android-arm-eabi": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.8.tgz",
+      "integrity": "sha512-7SKRmfT21Iwy1UJVirS89KO1YqA/nYeG6Te97Vi50e0Ua1XmmogE+ooUg4CNk0wevtVmgB3AHXK/1/ak6qY/Ag==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.122"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-android-arm64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.8.tgz",
+      "integrity": "sha512-K7PwYMOukAFUWR1f1xukNhQXpCWjYfOnBA130hdovuW7J+cxYX2O8L5cKW+VOmlTNXU561+k0jNSO5NkJ4pSSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-android-arm64/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.8.tgz",
+      "integrity": "sha512-sEynC48HWwYQ2RzJxBejnWfRQkl65f1+fWNjSWqAIii7I+fJT5La98hJrg+5dfZROBs34g1Zxt8+2Gttm25Nmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.8.tgz",
+      "integrity": "sha512-yimEqFZpmXU6uTnSw1A6umKBN1B68I+Cbl/q4IHm3Z3B9a/aymiQ7lJNrYYEHOgfpHLka4SWwvdSBSrpMczDfg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-freebsd-x64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.8.tgz",
+      "integrity": "sha512-kGGDDrKVCoM2A8lAJ3jFiWuafxtFxMmvkGlo72GikZsFDHibqr2K2+Ur++nwOz/ZFOf1HJwEbYVbbDa84pSlCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-freebsd-x64/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.8.tgz",
+      "integrity": "sha512-kLpA6Oei9J7u7NBFT80ziAe3cLhOV7vo/Li9rV44AI8iU6df7KXt7hvzmTyh5gXOg3f98wcMOakFF1FsKvSSdA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.8.tgz",
+      "integrity": "sha512-5W1sAM1lNmDfMy8DzRUiyjubDPZVIvzQRhdsP1zCDE/JKYaDJG8BzeSE6J3VdxNyLfe6tFvJTOCTyNAGWJBiTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.8.tgz",
+      "integrity": "sha512-xdmZX44xzjdG4zqIWEqkZVWukhw1lwVVLjXiQt94GZ9RISpUvanydIzahB/iuI/2/eWP4Stf6vyXn66ay1jIcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.8.tgz",
+      "integrity": "sha512-37YyUxXgLfiILzfoIkbfEB4mRJfWutaY9OThi9H1hLYaXLTfdWkk7bksALK473NY6/Vi/TrjYi1cz+GSteR/nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.8.tgz",
+      "integrity": "sha512-/MhCGWlIu2rjvUuGKNZSTLUm1jDus2ggmaZpbq87QSA8otPyKB4k5t6ySUzuSTRL8Qk/bLy1xjtjAv2sOzwzJA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.8.tgz",
+      "integrity": "sha512-UF4BoOtmquKSt5eIODvrimqLLTG30vuIvY8z1/3RJyzCI3uZE3csetmAMvry8ioS1vC5DFETNh4xFO20CJvR0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.8.tgz",
+      "integrity": "sha512-ZsLm+Gimv8RO77AQjkaqs4jncw7AmR5HgR+I6gSRsVhLEo3tRbzSK2br98PRC217RA86Ei148/WUutu9IA7/5g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "@swc/wasm": "1.2.130"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc/node_modules/@swc/wasm": {
+      "version": "1.2.130",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+      "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.8.tgz",
+      "integrity": "sha512-7Kxx6K4hEbwjj3IyD5hqoUGbOtuYJoMUh6ac+gce22oxq4sWWkVRbV0s+oJSXqWA0/PCu07t0m1/B4Z0MpqwuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/wasm": {
+      "version": "1.2.122",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.122.tgz",
+      "integrity": "sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -11807,6 +12109,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/swc-loader": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz",
+      "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==",
+      "dev": true,
+      "peerDependencies": {
+        "@swc/core": "^1.2.147",
+        "webpack": ">=2"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -15381,6 +15693,188 @@
         "@svgr/plugin-jsx": "^6.2.1",
         "@svgr/plugin-svgo": "^6.2.0"
       }
+    },
+    "@swc/core": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.8.tgz",
+      "integrity": "sha512-EEinXtV7MvzWt1dgqnkfUaxCwPnSo3ZeWQzTpppCZFkM9hn+kfViTig2aS1aoXvwi/SsDZ51DDs4st8xr4yqhQ==",
+      "dev": true,
+      "requires": {
+        "@swc/core-android-arm-eabi": "1.3.8",
+        "@swc/core-android-arm64": "1.3.8",
+        "@swc/core-darwin-arm64": "1.3.8",
+        "@swc/core-darwin-x64": "1.3.8",
+        "@swc/core-freebsd-x64": "1.3.8",
+        "@swc/core-linux-arm-gnueabihf": "1.3.8",
+        "@swc/core-linux-arm64-gnu": "1.3.8",
+        "@swc/core-linux-arm64-musl": "1.3.8",
+        "@swc/core-linux-x64-gnu": "1.3.8",
+        "@swc/core-linux-x64-musl": "1.3.8",
+        "@swc/core-win32-arm64-msvc": "1.3.8",
+        "@swc/core-win32-ia32-msvc": "1.3.8",
+        "@swc/core-win32-x64-msvc": "1.3.8"
+      }
+    },
+    "@swc/core-android-arm-eabi": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.3.8.tgz",
+      "integrity": "sha512-7SKRmfT21Iwy1UJVirS89KO1YqA/nYeG6Te97Vi50e0Ua1XmmogE+ooUg4CNk0wevtVmgB3AHXK/1/ak6qY/Ag==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.122"
+      }
+    },
+    "@swc/core-android-arm64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.3.8.tgz",
+      "integrity": "sha512-K7PwYMOukAFUWR1f1xukNhQXpCWjYfOnBA130hdovuW7J+cxYX2O8L5cKW+VOmlTNXU561+k0jNSO5NkJ4pSSQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-darwin-arm64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.8.tgz",
+      "integrity": "sha512-sEynC48HWwYQ2RzJxBejnWfRQkl65f1+fWNjSWqAIii7I+fJT5La98hJrg+5dfZROBs34g1Zxt8+2Gttm25Nmg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.8.tgz",
+      "integrity": "sha512-yimEqFZpmXU6uTnSw1A6umKBN1B68I+Cbl/q4IHm3Z3B9a/aymiQ7lJNrYYEHOgfpHLka4SWwvdSBSrpMczDfg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-freebsd-x64": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.3.8.tgz",
+      "integrity": "sha512-kGGDDrKVCoM2A8lAJ3jFiWuafxtFxMmvkGlo72GikZsFDHibqr2K2+Ur++nwOz/ZFOf1HJwEbYVbbDa84pSlCw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.8.tgz",
+      "integrity": "sha512-kLpA6Oei9J7u7NBFT80ziAe3cLhOV7vo/Li9rV44AI8iU6df7KXt7hvzmTyh5gXOg3f98wcMOakFF1FsKvSSdA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.8.tgz",
+      "integrity": "sha512-5W1sAM1lNmDfMy8DzRUiyjubDPZVIvzQRhdsP1zCDE/JKYaDJG8BzeSE6J3VdxNyLfe6tFvJTOCTyNAGWJBiTA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.8.tgz",
+      "integrity": "sha512-xdmZX44xzjdG4zqIWEqkZVWukhw1lwVVLjXiQt94GZ9RISpUvanydIzahB/iuI/2/eWP4Stf6vyXn66ay1jIcA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.8.tgz",
+      "integrity": "sha512-37YyUxXgLfiILzfoIkbfEB4mRJfWutaY9OThi9H1hLYaXLTfdWkk7bksALK473NY6/Vi/TrjYi1cz+GSteR/nw==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.8.tgz",
+      "integrity": "sha512-/MhCGWlIu2rjvUuGKNZSTLUm1jDus2ggmaZpbq87QSA8otPyKB4k5t6ySUzuSTRL8Qk/bLy1xjtjAv2sOzwzJA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.8.tgz",
+      "integrity": "sha512-UF4BoOtmquKSt5eIODvrimqLLTG30vuIvY8z1/3RJyzCI3uZE3csetmAMvry8ioS1vC5DFETNh4xFO20CJvR0g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.8.tgz",
+      "integrity": "sha512-ZsLm+Gimv8RO77AQjkaqs4jncw7AmR5HgR+I6gSRsVhLEo3tRbzSK2br98PRC217RA86Ei148/WUutu9IA7/5g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@swc/wasm": "1.2.130"
+      },
+      "dependencies": {
+        "@swc/wasm": {
+          "version": "1.2.130",
+          "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.130.tgz",
+          "integrity": "sha512-rNcJsBxS70+pv8YUWwf5fRlWX6JoY/HJc25HD/F8m6Kv7XhJdqPPMhyX6TKkUBPAG7TWlZYoxa+rHAjPy4Cj3Q==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.8.tgz",
+      "integrity": "sha512-7Kxx6K4hEbwjj3IyD5hqoUGbOtuYJoMUh6ac+gce22oxq4sWWkVRbV0s+oJSXqWA0/PCu07t0m1/B4Z0MpqwuA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/wasm": {
+      "version": "1.2.122",
+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.2.122.tgz",
+      "integrity": "sha512-sM1VCWQxmNhFtdxME+8UXNyPNhxNu7zdb6ikWpz0YKAQQFRGT5ThZgJrubEpah335SUToNg8pkdDF7ibVCjxbQ==",
+      "dev": true,
+      "optional": true
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
@@ -21837,6 +22331,13 @@
           "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
         }
       }
+    },
+    "swc-loader": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.2.3.tgz",
+      "integrity": "sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==",
+      "dev": true,
+      "requires": {}
     },
     "tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.1.0",
+    "@swc/core": "1.3.8",
     "@tsconfig/docusaurus": "1.0.6",
     "@types/mermaid": "9.1.0",
     "prettier": "2.7.1",
     "rimraf": "3.0.2",
+    "swc-loader": "0.2.3",
     "typescript": "4.8.4"
   }
 }


### PR DESCRIPTION
Speed up build using `swc` as recommended for larger repo's (for example the [docusaurus website itself](https://github.com/facebook/docusaurus/blob/main/website/docusaurus.config.js#L104-L120)). 

16% faster than the default (babel) and _slightly_ faster than esbuild for clean builds.

![image](https://user-images.githubusercontent.com/10114577/195860778-161ce5e8-a6ed-4b1d-9994-7b6173a93cf8.png)

For cached (or subsequent builds, dev mode etc) it's already fairly fast, but swc still wins out:

![image](https://user-images.githubusercontent.com/10114577/195860896-06c08b45-9f71-4231-bd08-b12ee048a953.png)
