### PR TITLE
docs(site): Add metaphor-free TL;DR  to Introduction

### DIFF
--- a/docs/General/introduction.mdx
+++ b/docs/General/introduction.mdx
@@ -5,6 +5,8 @@ slug: '/'
 sidebar_position: 1
 ---
 
+**TL; DR: Mutation testing changes the return statements in your functions, to verify that the tests that cover them, actually fail properly as a result.**
+
 Bugs, or _mutants_, are automatically inserted into your production code. Your tests are run for each mutant. If your tests _fail_ then the mutant is _killed_. If your tests passed, the mutant _survived_. The higher the percentage of mutants killed, the more _effective_ your tests are.
 
 It's that simple.

--- a/docs/General/introduction.mdx
+++ b/docs/General/introduction.mdx
@@ -5,7 +5,7 @@ slug: '/'
 sidebar_position: 1
 ---
 
-**TL; DR: Mutation testing introduces changes to your code, then runs your unit tests against the changed code. It is expected that your unit tests now fail. If they don't fail for a change in the code this indicates the code is not sufficiently covered by your tests.**
+**TL; DR: Mutation testing introduces changes to your code, then runs your unit tests against the changed code. It is expected that your unit tests will now fail. If they don't fail, it might indicate your tests do not sufficiently cover the code.**
 
 Bugs, or _mutants_, are automatically inserted into your production code. Your tests are run for each mutant. If your tests _fail_ then the mutant is _killed_. If your tests passed, the mutant _survived_. The higher the percentage of mutants killed, the more _effective_ your tests are.
 

--- a/docs/General/introduction.mdx
+++ b/docs/General/introduction.mdx
@@ -5,7 +5,7 @@ slug: '/'
 sidebar_position: 1
 ---
 
-**TL; DR: Mutation testing changes little parts of your code to change the outcome, to verify that the tests that cover them, actually fail properly as a result.**
+**TL; DR: Mutation testing introduces changes to your code, then runs your unit tests against the changed code. It is expected that your unit tests now fail. If they don't fail for a change in the code this indicates the code is not sufficiently covered by your tests.**
 
 Bugs, or _mutants_, are automatically inserted into your production code. Your tests are run for each mutant. If your tests _fail_ then the mutant is _killed_. If your tests passed, the mutant _survived_. The higher the percentage of mutants killed, the more _effective_ your tests are.
 

--- a/docs/General/introduction.mdx
+++ b/docs/General/introduction.mdx
@@ -5,7 +5,7 @@ slug: '/'
 sidebar_position: 1
 ---
 
-**TL; DR: Mutation testing changes the return statements in your functions, to verify that the tests that cover them, actually fail properly as a result.**
+**TL; DR: Mutation testing changes little parts of your code to change the outcome, to verify that the tests that cover them, actually fail properly as a result.**
 
 Bugs, or _mutants_, are automatically inserted into your production code. Your tests are run for each mutant. If your tests _fail_ then the mutant is _killed_. If your tests passed, the mutant _survived_. The higher the percentage of mutants killed, the more _effective_ your tests are.
 


### PR DESCRIPTION
I had a lot of trouble understanding this page because it immediately forces me into a mental model of 'mutants' and 'mutations' that only serve to distract me from understanding the gist of mutation testing. Mutation itself is even confusing because it make me think of network calls that do data mutations. It also confuses me because it reminds me of mutable vs immutable approaches in code.

This TL;DR summarises the page in a neutral way, without references to metaphors, that I believe would have made me got the concept right away.