### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -221,6 +221,7 @@ const config: Config = {
     ],
   ],
   plugins: [
+    'docusaurus-plugin-copy-page-button',
     ['@docusaurus/plugin-client-redirects', { redirects }],
     [
       '@docusaurus/plugin-pwa',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@docusaurus/theme-common": "3.10.1",
     "@docusaurus/theme-mermaid": "3.10.1",
     "@giscus/react": "3.1.0",
+    "docusaurus-plugin-copy-page-button": "^0.8.3",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@giscus/react':
         specifier: 3.1.0
         version: 3.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      docusaurus-plugin-copy-page-button:
+        specifier: ^0.8.3
+        version: 0.8.3(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.41)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.11)(@swc/core@1.15.41)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react@19.2.7)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -3317,6 +3320,13 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  docusaurus-plugin-copy-page-button@0.8.3:
+    resolution: {integrity: sha512-2/k4H/ePsuZUVv5S91XC2zhnIWLufHzEPTdo/6jYcvonQqHKcLK9vfOp24L5qwMO16VGhHRIEYcEVrXOshxaBw==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: ^18.0.0 || ^19.0.0
 
   dom-converter@0.2.0:
     resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
@@ -11163,6 +11173,11 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  docusaurus-plugin-copy-page-button@0.8.3(@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.41)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.11)(@swc/core@1.15.41)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(react@19.2.7):
+    dependencies:
+      '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.41)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.11)(@swc/core@1.15.41)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      react: 19.2.7
 
   dom-converter@0.2.0:
     dependencies:


### PR DESCRIPTION
This PR
- adds docusaurus-plugin-copy-page-button to package.json
- adds the plugin string to plugins in docusaurus.config.ts
- puts a "Copy page" button in the docs sidebar — exports current page as clean markdown
- adds one-click "Open in Claude / ChatGPT / Gemini" actions that prefill the markdown

(PR targets the develop branch)

why useful for Stryker specifically:
mutation testing is config-heavy and spread across runners (StrykerJS, Stryker.NET, Stryker4s) — the typical flow is reading a configuration or getting-started page → wanting to paste just that page into an LLM to generate a stryker.conf for a specific setup or debug why mutants aren't being killed. this saves the select-and-clean step and keeps the LLM grounded in your actual docs rather than guessing config keys.

zero config, auto-injects into the TOC sidebar, theme-aware.

shipping on React Native, Redux Toolkit, Puppeteer, pnpm, PlayCanvas, Arbitrum, Cardano, Sui, Nillion, Flare, Kaia, and ~20 other docs sites. listed on the Docusaurus community plugins page.

happy to close/rebase if not a fit
- repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button
